### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#j2js-compiler
+# j2js-compiler
 
 A Java Bytecode to JavaScript Cross-Compiler.
 
-##Installation
+## Installation
 
 1. You need to install this and the following projects
 
@@ -14,31 +14,31 @@ A Java Bytecode to JavaScript Cross-Compiler.
 
 3. Optionally install https://github.com/decatur/j2js-demos
 
-##Building your project
+## Building your project
 
 It is highly recommended that you compile your project (i.e. generate class files) against `j2js-jre`, and not `rt.jar`. This way you avoid link errors (missing classes or methods) at the cross-compile stage. See the warning at the bottom of the document.
 
-##Usage
+## Usage
 
     java -cp <RUNTIME_CLASSPATH> com.j2js.J2JSCompiler <basedir> <CROSS_COMPILE_CLASSPATH> <entryPointClassName> <targetLocation>
 
-###`<RUNTIME_CLASSPATH>`
+### `<RUNTIME_CLASSPATH>`
 
 This is the standard Java classpath.
 The cross-compiler needs the project j2js-compiler, bcel and commons-io on its classpath. 
 
-###`<basedir>`
+### `<basedir>`
 
 All non-absolute paths are relative to the basedir.
 
-###`<entryPointClassName>`
+### `<entryPointClassName>`
 
 The name of the class to cross-compile. This class must have a method
 `public void main(java.lang.String[])`.
 
 The compiler cross-compiles the `main` method and all other methods which are called from the `main` method.
 
-###`<CROSS_COMPILE_CLASSPATH>`
+### `<CROSS_COMPILE_CLASSPATH>`
 
 This classpath must contain all classes whose methods are referenced by the main method.
 In normal operation, this classpath consists of
@@ -46,12 +46,12 @@ In normal operation, this classpath consists of
 * the j2js-agent classes directory or jar
 * the classes directory of your personal project
 
-###`<targetLocation>`
+### `<targetLocation>`
 All cross-compiled code is stored in the target location. It is one or more JavaScript file starting at
 `0.js`. Only this initial file must be included in your web page with
 `<script src='targetLocation/0.js'/>`.
 
-###Example
+### Example
 
 Suppose the directory layout is
 
@@ -76,13 +76,13 @@ and you want to cross-compile class `org.mydomain.my-project.MyClass`. Then
 
 will create the assemblies.
 
-##Warning
+## Warning
 The project `j2js-jre` contains a hand-crafted version of the Java Runtime Environment. Do not put `Java/jreX/lib/rt.jar` into the `<CROSS_COMPILE_CLASSPATH>`.
 
-##Limitations
+## Limitations
 The cross-compiler is able to translate any legal Java Bytecode. However, naturally, the compiler cannot support the Java Native Interface (JNI).
 
-##Cross Compiling Scala
+## Cross Compiling Scala
 The current Scala version uses JRE classes such as `ClassLoader` or `SecurityContext` even in base Scala classes. These JRE classes do not make sense in a web agent context and are therefore not implemented in `j2js-jre`.
 
 A workaround would be to hand-craft a subset of Scala classes, avoiding dependencies to JRE classes such as `ClassLoader`. But this is a lot of work.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
